### PR TITLE
Fix issues with order tracker page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,13 +5,12 @@ import Home from './pages/Home';
 import Order from './pages/Order';
 import Stock from './pages/Stock';
 import OrderStock from './pages/OrderStock';
-import SocketTest from './pages/SocketTest'
-
+import OrderTracker from './pages/OrderTracker';
 
 function App() {
   return (
     <Router basename={process.env.PUBLIC_URL}>
-      <Navbar ç/>
+      <Navbar ç />
       <br />
       <Switch>
         <Route exact path="/">
@@ -27,10 +26,12 @@ function App() {
           <OrderStock />
         </Route>
         <Route path="/order-tracker">
-          <SocketTest />
+          <OrderTracker />
         </Route>
         <Route path="*">
-          <h1>Welcome to <font style={{color:'#26B020'}}>Pan-Lang</font>!</h1>
+          <h1>
+            Welcome to <font style={{ color: '#26B020' }}>Pan-Lang</font>!
+          </h1>
         </Route>
       </Switch>
     </Router>

--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,7 @@ function App() {
         <Route path="/order-stock">
           <OrderStock />
         </Route>
-        <Route path="/sockettest">
+        <Route path="/order-tracker">
           <SocketTest />
         </Route>
         <Route path="*">

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -14,7 +14,7 @@ function NavigationBar() {
       <Nav className="mr-auto">
         <Nav.Link as={Link} to="/order">Order</Nav.Link>
         <Nav.Link as={Link} to="/stock">Stock</Nav.Link>
-        <Nav.Link as={Link} to="/sockettest">Order Tracker</Nav.Link>
+        <Nav.Link as={Link} to="/order-tracker">Order Tracker</Nav.Link>
       </Nav>
     </Navbar>
   );

--- a/src/pages/OrderTracker.js
+++ b/src/pages/OrderTracker.js
@@ -7,7 +7,7 @@ import { BASE_API_URL } from '../api/Client';
 /**
  * Page with list of people with unfulfilled orders
  */
-function OrderTrackerPage() {
+function OrderTracker() {
   const [ordersList, setOrdersList] = useState([]);
   const socket = socketIOClient(BASE_API_URL);
 
@@ -49,4 +49,4 @@ function OrderTrackerPage() {
   );
 }
 
-export default OrderTrackerPage;
+export default OrderTracker;

--- a/src/pages/SocketTest.js
+++ b/src/pages/SocketTest.js
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import socketIOClient from 'socket.io-client';
 import Container from 'react-bootstrap/Container';
-import Loading from '../components/Loading';
 import { useHistory } from 'react-router-dom';
 import UnfulfilledOrderCard from '../components/UnfulfilledOrderCard';
-const ENDPOINT = 'https://panlang.herokuapp.com/'; 
-
+import { BASE_API_URL } from '../api/Client';
 
 // List of people with unfulfilled orders
 let listPeople = [];
@@ -16,11 +14,11 @@ let listPeople = [];
 function OrderTrackerPage() {
   const history = useHistory();
   const [response, setResponse] = useState(listPeople);
-  const socket = socketIOClient(ENDPOINT);
+  const socket = socketIOClient(BASE_API_URL);
 
   useEffect(() => {
     socket.on('person', (data) => {
-      console.log(data)
+      console.log(data);
       eventHandler(data);
     });
 
@@ -33,7 +31,7 @@ function OrderTrackerPage() {
       console.log('effect done');
       socket.off('person', eventHandler);
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function personFulfilled(id) {
@@ -44,7 +42,7 @@ function OrderTrackerPage() {
 
   return (
     <Container>
-      {listPeople.length === 0 && <Loading />}
+      {listPeople.length === 0 && <p>No orders at the moment.</p>}
       {response &&
         response.map((person) => (
           <UnfulfilledOrderCard

--- a/src/pages/SocketTest.js
+++ b/src/pages/SocketTest.js
@@ -1,19 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import socketIOClient from 'socket.io-client';
 import Container from 'react-bootstrap/Container';
-import { useHistory } from 'react-router-dom';
 import UnfulfilledOrderCard from '../components/UnfulfilledOrderCard';
 import { BASE_API_URL } from '../api/Client';
-
-// List of people with unfulfilled orders
-let listPeople = [];
 
 /**
  * Page with list of people with unfulfilled orders
  */
 function OrderTrackerPage() {
-  const history = useHistory();
-  const [response, setResponse] = useState(listPeople);
+  const [ordersList, setOrdersList] = useState([]);
   const socket = socketIOClient(BASE_API_URL);
 
   useEffect(() => {
@@ -22,9 +17,8 @@ function OrderTrackerPage() {
       eventHandler(data);
     });
 
-    const eventHandler = (data) => {
-      listPeople = listPeople.concat(data);
-      setResponse(listPeople);
+    const eventHandler = (personData) => {
+      setOrdersList(ordersList.concat(personData));
     };
 
     return () => {
@@ -36,19 +30,19 @@ function OrderTrackerPage() {
 
   function personFulfilled(id) {
     socket.emit('personFulfilled', id);
-    // Refresh the page after emitting fulfillment
-    history.go(0);
+    // Remove fulfilled order from list after emitting fulfillment through socket
+    setOrdersList(ordersList.filter((order) => order._id !== id));
   }
 
   return (
     <Container>
-      {listPeople.length === 0 && <p>No orders at the moment.</p>}
-      {response &&
-        response.map((person) => (
+      {ordersList.length === 0 && <p>No orders at the moment.</p>}
+      {ordersList &&
+        ordersList.map((order) => (
           <UnfulfilledOrderCard
             fulfillPerson={personFulfilled}
-            person={person}
-            key={person._id}
+            person={order}
+            key={order._id}
           />
         ))}
     </Container>


### PR DESCRIPTION
## What this pr does

Closes #15
- Current workaround is to filter the orders list of fulfilled orders by id
- Page still 404s upon refresh, but this is a known issue for SPAs on GitHub pages; will fix later

Closes #16 
- renamed to `/order-tracker`

Closes #17
- gives simple message when no orders are present
- need to figure out how to give loading state to socket requests